### PR TITLE
Fix/windows test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ Internal Bitwarden calls force JSON and disable color, then bwenv applies its en
 
 Go version and dependencies are declared in `go.mod`.
 
+Use feature branches off `main` and open pull requests. Never push directly to `main`.
+
+```bash
+git checkout -b fix/my-change
+# make changes, commit
+git push origin fix/my-change
+# open PR at the URL shown
+```
+
 ```bash
 make verify       # formatting, vet, unit tests, shell syntax, doc links
 make test-race    # race detector

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,11 @@ For a manual integration test, install the official `bws` CLI and use a disposab
 ## Making a change
 
 1. Open an issue for substantial behavioral or command-interface changes.
-2. Keep Bitwarden subprocess logic in `internal/bws` and environment naming/merge behavior in `internal/environment`.
-3. Add or update tests for successful behavior, validation failures, subprocess failures, and secret-redaction boundaries.
-4. Update the canonical documents under `docs/` when behavior changes.
-5. Run `make verify`, `make test-race`, and `make build-all` before opening a pull request.
+2. Create a feature branch from `main` (e.g., `fix/description` or `feat/description`).
+3. Keep Bitwarden subprocess logic in `internal/bws` and environment naming/merge behavior in `internal/environment`.
+4. Add or update tests for successful behavior, validation failures, subprocess failures, and secret-redaction boundaries.
+5. Update the canonical documents under `docs/` when behavior changes.
+6. Run `make verify`, `make test-race`, and `make build-all` before opening a pull request.
 
 Use `gofmt`; do not hand-format Go code. Error messages must not include secret values or access tokens. Verbose subprocess logs must mask both.
 
@@ -42,6 +43,8 @@ make lint       # golangci-lint, when installed
 `docs/` is also the source of truth for coding agents. Prefer precise behavior, commands, precedence rules, and failure modes over marketing language. Update `docs/README.md` whenever adding or removing a document, then run `scripts/check-doc-links.sh`.
 
 ## Pull requests
+
+Push your feature branch to origin and open a pull request against `main`. Never push directly to `main`.
 
 Explain the user-visible outcome and why the chosen approach fits bwenv’s narrow scope. Include test evidence. Keep unrelated refactors out of the same pull request, and note any security or compatibility implications explicitly.
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -202,7 +202,7 @@ func TestRunStripsTokenAndAppliesSharedPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stdout != "app" {
+	if strings.TrimRight(stdout, "\r\n") != "app" {
 		t.Fatalf("unexpected child output: %q", stdout)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -191,7 +192,12 @@ func TestRunStripsTokenAndAppliesSharedPrecedence(t *testing.T) {
 		{ID: "1", Key: "shared__TOKEN", Value: "shared"},
 		{ID: "2", Key: "photos__TOKEN", Value: "app"},
 	}}
-	command := `test -z "$BWS_ACCESS_TOKEN" && printf '%s' "$TOKEN"`
+	var command string
+	if runtime.GOOS == "windows" {
+		command = `if (-not $env:BWS_ACCESS_TOKEN) { Write-Output $env:TOKEN }`
+	} else {
+		command = `test -z "$BWS_ACCESS_TOKEN" && printf '%s' "$TOKEN"`
+	}
 	stdout, _, err := executeForTest(t, client, "", "run", "photos", "--include-shared", "--", command)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**Problem:** `TestRunStripsTokenAndAppliesSharedPrecedence` hardcodes a Unix shell
command (`test -z && printf`), which fails on Windows where `run` defaults to
PowerShell.

**Fix:** Make the test command platform-aware — Unix keeps `sh` syntax, Windows
uses PowerShell syntax. Also documents the branch-from-main workflow in
AGENTS.md and CONTRIBUTING.md so future contributors know the process.

**Test evidence:**
- `go test ./cmd/ -run TestRunStripsTokenAndAppliesSharedPrecedence` passes on
  macOS (native)
- Cross-compilation succeeds: `GOOS=windows go build ./...`
- All existing tests still pass
