### PR TITLE
chore: update Homebrew formula for v1.1.0

### DIFF
--- a/Formula/bwenv.rb
+++ b/Formula/bwenv.rb
@@ -1,7 +1,7 @@
 class Bwenv < Formula
   desc "App-scoped environments backed by Bitwarden Secrets Manager"
   homepage "https://github.com/saiteja-madha/bwenv"
-  version "1.0.0"
+  version "1.1.0"
   license "MIT"
   head "https://github.com/saiteja-madha/bwenv.git", branch: "main" do
     depends_on "go" => :build
@@ -9,21 +9,21 @@ class Bwenv < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.0.0/bwenv-darwin-arm64", using: :nounzip
-      sha256 "e4e8566d953631b88c3a3d506471c0d5e93e9c5296140b246f223cbdebec0ff4"
+      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.1.0/bwenv-darwin-arm64", using: :nounzip
+      sha256 "7a128804c3dae257e5256f157ed1d41125f9145bd82ccade3f6cf294aefb582c"
     else
-      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.0.0/bwenv-darwin-amd64", using: :nounzip
-      sha256 "4aa0b9ee4c4f99c0d2e70fe17ababa2984e52c00507861b5d9f5dc6d3d46795c"
+      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.1.0/bwenv-darwin-amd64", using: :nounzip
+      sha256 "50fc072a6e6f5f36c407e894704e21e9aa67fcde9fb03ec72475153c68045072"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.0.0/bwenv-linux-arm64", using: :nounzip
-      sha256 "1ceb0d31a5c4f43afc5af88f3bf94a3b0d92c18d8b82a8f41d8c5b061aa0e182"
+      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.1.0/bwenv-linux-arm64", using: :nounzip
+      sha256 "7bab71f9745533f28c4d8ecf260efd298f4dd928ad7f10c2d050d3771ed5c0d9"
     else
-      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.0.0/bwenv-linux-amd64", using: :nounzip
-      sha256 "c45fca0a306b38b9859c6bb2a158185d10458194e4da08a42f347c6210c6d2ab"
+      url "https://github.com/saiteja-madha/bwenv/releases/download/v1.1.0/bwenv-linux-amd64", using: :nounzip
+      sha256 "92dc1ada5144884db6a032f8fec1b411044159ab42ca844e668c05aee3427719"
     end
   end
 


### PR DESCRIPTION
Automated stable-formula update using the checksums from the
`v1.1.0` release.